### PR TITLE
카테고리 테이블 뷰 - 셀 눌렀을 때 딱! 하나만 접었다 펴는 기능 완료

### DIFF
--- a/MarketBroccoli/MarketBroccoli/Source/ViewControllers/CategoryViewController.swift
+++ b/MarketBroccoli/MarketBroccoli/Source/ViewControllers/CategoryViewController.swift
@@ -11,7 +11,6 @@ import UIKit
 class CategoryViewController: UIViewController {
   var tableView = UITableView(frame: .zero, style: .grouped)
   let oftenProduct = ["자주 사는 상품"]
-//  let temp = ["컬리의 추천"]
   
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -55,27 +54,8 @@ extension CategoryViewController: UITableViewDataSource {
     return categoryData.count + 2
   }
   
-  func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-   if section == 2 {
-      return 80
-    } else {
-      return 0
-    }
-  }
-  
   func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
     return 1
-
-//    switch section {
-//    case 0:
-//      return 1
-//    case 1:
-//      return categoryData.count
-//    case 2:
-//      return 1
-//    default:
-//      return 0
-//    }
   }
   func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     switch indexPath.section {
@@ -97,11 +77,6 @@ extension CategoryViewController: UITableViewDataSource {
             cell.titleName(name: data.title)
             cell.subCategory(data: data)
             cell.separatorInset = .zero
-      //      if data.select == false {
-      //        cell.iconImageName(name: data.imageBlack)
-      //      } else {
-      //        cell.iconImageName(name: data.imagePurple)
-      //      }
             return cell
     }
   }
@@ -109,29 +84,50 @@ extension CategoryViewController: UITableViewDataSource {
 
 // MARK: - TableViewDelegate
 extension CategoryViewController: UITableViewDelegate {
-  func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-    if indexPath.section == 0 {
-      return 60
-    } else {
-      return UITableView.automaticDimension
+  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    switch indexPath.section {
+    case 0, 16:
+      print(indexPath.section)
+    default:
+      categoryData[indexPath.section - 1].select.toggle()
+      tableView.reloadData()
+      print(categoryData[indexPath.section - 1].select)
+      print(indexPath.section)
     }
   }
   func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-      return UIView()
-  }
+       return UIView()
+   }
 
-  func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-      return 0.1
+  func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+    return " "
   }
-  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    if indexPath.section == 1 {
-      categoryData[indexPath.row].select.toggle()
-//      tableView.beginUpdates()
-//      tableView.endUpdates()
-      tableView.reloadData()
-//      tableView.reloadRows(at: [indexPath], with: .automatic)
-      print(categoryData[indexPath.row].select)
-      print(indexPath.row)
+  
+  func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+    return "footer"
+  }
+  
+  func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+    switch section {
+    case 16:
+      return 20
+    default:
+      return 0
     }
   }
+  func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+    switch section {
+    case 0:
+      return 20
+    default:
+      return 0
+    }
+  }
+  func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+     if indexPath.section == 0 {
+       return 60
+     } else {
+       return UITableView.automaticDimension
+     }
+   }
 }

--- a/MarketBroccoli/MarketBroccoli/Source/ViewControllers/CategoryViewController.swift
+++ b/MarketBroccoli/MarketBroccoli/Source/ViewControllers/CategoryViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 class CategoryViewController: UIViewController {
   var tableView = UITableView(frame: .zero, style: .grouped)
   let oftenProduct = ["자주 사는 상품"]
-  let temp = ["컬리의 추천"]
+//  let temp = ["컬리의 추천"]
   
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -51,7 +51,8 @@ class CategoryViewController: UIViewController {
 // MARK: - TableViewDataSource
 extension CategoryViewController: UITableViewDataSource {
   func numberOfSections(in tableView: UITableView) -> Int {
-    3
+//    3
+    return categoryData.count + 2
   }
   
   func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
@@ -63,49 +64,45 @@ extension CategoryViewController: UITableViewDataSource {
   }
   
   func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    switch section {
-    case 0:
-      return 1
-    case 1:
-      return categoryData.count
-    case 2:
-      return 1
-    default:
-      return 0
-    }
+    return 1
+
+//    switch section {
+//    case 0:
+//      return 1
+//    case 1:
+//      return categoryData.count
+//    case 2:
+//      return 1
+//    default:
+//      return 0
+//    }
   }
   func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     switch indexPath.section {
     case 0:
       let cell = tableView.dequeueReusableCell(withIdentifier: "often", for: indexPath)
-      cell.textLabel?.text = oftenProduct[indexPath.row]
+      cell.textLabel?.text = oftenProduct[indexPath.section]
       cell.textLabel?.textColor = #colorLiteral(red: 0.3176470588, green: 0.1529411765, blue: 0.4470588235, alpha: 1)
-      
       let image = UIImageView(image: UIImage(systemName: "chevron.right"))
       cell.accessoryView = image
       cell.accessoryView?.tintColor = #colorLiteral(red: 0.3176470588, green: 0.1529411765, blue: 0.4470588235, alpha: 1)
-      
       return cell
-    case 1:
-      let cell = tableView.dequeue(CategoryTableViewCell.self)
-      let data = categoryData[indexPath.row]
-      cell.titleName(name: data.title)
-      cell.subCategory(data: data)
-      cell.separatorInset = .zero
-//      if data.select == false {
-//        cell.iconImageName(name: data.imageBlack)
-//      } else {
-//        cell.iconImageName(name: data.imagePurple)
-//      }
-      return cell
-    case 2:
+    case 16:
       let cell = tableView.dequeueReusableCell(withIdentifier: "temp", for: indexPath)
-      cell.textLabel?.text = temp[indexPath.row]
+      cell.textLabel?.text = "컬리의 추천"
       return cell
     default:
-      let cell = tableView.dequeueReusableCell(withIdentifier: "often", for: indexPath)
-      cell.textLabel?.text = oftenProduct[indexPath.row]
-      return cell
+      let cell = tableView.dequeue(CategoryTableViewCell.self)
+            let data = categoryData[indexPath.section - 1]
+            cell.titleName(name: data.title)
+            cell.subCategory(data: data)
+            cell.separatorInset = .zero
+      //      if data.select == false {
+      //        cell.iconImageName(name: data.imageBlack)
+      //      } else {
+      //        cell.iconImageName(name: data.imagePurple)
+      //      }
+            return cell
     }
   }
 }
@@ -113,13 +110,10 @@ extension CategoryViewController: UITableViewDataSource {
 // MARK: - TableViewDelegate
 extension CategoryViewController: UITableViewDelegate {
   func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-    if indexPath.section == 1 {
-      return UITableView.automaticDimension
-    }
-    if indexPath.section == 2 {
-      return 400
-    } else {
+    if indexPath.section == 0 {
       return 60
+    } else {
+      return UITableView.automaticDimension
     }
   }
   func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {

--- a/MarketBroccoli/MarketBroccoli/Source/ViewControllers/CategoryViewController.swift
+++ b/MarketBroccoli/MarketBroccoli/Source/ViewControllers/CategoryViewController.swift
@@ -30,10 +30,11 @@ class CategoryViewController: UIViewController {
       UIView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: (view.frame.height) * 0.02))
     tableView.tableFooterView =
       UIView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: (view.frame.height) * 0.02))
-//    tableView.separatorStyle = .none // 테이블 뷰 라인 없애기
+    tableView.separatorStyle = .none // 테이블 뷰 라인 없애기
     tableView.register(cell: CategoryTableViewCell.self)
     tableView.register(UITableViewCell.self, forCellReuseIdentifier: "often")
     tableView.register(UITableViewCell.self, forCellReuseIdentifier: "temp")
+    tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
     [tableView].forEach {
       view.addSubview($0)
     }
@@ -55,8 +56,20 @@ extension CategoryViewController: UITableViewDataSource {
   }
   
   func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return 1
+    switch section {
+    case 0, 16:
+      return 1
+    default:
+//      print(section)
+//      return 1
+      if categoryData[section - 1].select {
+        return categoryData[section - 1].row.count + 1
+      } else {
+        return 1
+      }
+    }
   }
+  
   func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     switch indexPath.section {
     case 0:
@@ -72,12 +85,18 @@ extension CategoryViewController: UITableViewDataSource {
       cell.textLabel?.text = "컬리의 추천"
       return cell
     default:
-      let cell = tableView.dequeue(CategoryTableViewCell.self)
-            let data = categoryData[indexPath.section - 1]
-            cell.titleName(name: data.title)
-            cell.subCategory(data: data)
-            cell.separatorInset = .zero
-            return cell
+      if indexPath.row == 0 {
+        let cell = tableView.dequeue(CategoryTableViewCell.self)
+        let data = categoryData[indexPath.section - 1]
+        cell.titleName(name: data.title)
+        cell.subCategory(data: data)
+        cell.separatorInset = .zero
+        return cell
+      } else {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: "cell") else { return UITableViewCell() }
+        cell.textLabel?.text = categoryData[indexPath.section - 1].row[indexPath.row - 1]
+        return cell
+      }
     }
   }
 }
@@ -89,10 +108,15 @@ extension CategoryViewController: UITableViewDelegate {
     case 0, 16:
       print(indexPath.section)
     default:
-      categoryData[indexPath.section - 1].select.toggle()
-      tableView.reloadData()
-      print(categoryData[indexPath.section - 1].select)
-      print(indexPath.section)
+      if indexPath.row == 0 {
+        categoryData[indexPath.section - 1].select.toggle()
+//        tableView.reloadData()
+        let row = IndexSet.init(integer: indexPath.section)
+        tableView.reloadSections(row, with: .none)
+      } else {
+        // Todo: 다음페이지 넘김
+        print(indexPath.row)
+      }
     }
   }
   func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
@@ -102,7 +126,7 @@ extension CategoryViewController: UITableViewDelegate {
   func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
     return " "
   }
-  
+
   func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
     return "footer"
   }

--- a/MarketBroccoli/MarketBroccoli/Source/ViewControllers/CategoryViewController.swift
+++ b/MarketBroccoli/MarketBroccoli/Source/ViewControllers/CategoryViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 class CategoryViewController: UIViewController {
   var tableView = UITableView(frame: .zero, style: .grouped)
   let oftenProduct = ["자주 사는 상품"]
+  var lastSelection: IndexPath?
   
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -27,14 +28,12 @@ class CategoryViewController: UIViewController {
     tableView.dataSource = self
     tableView.delegate = self
     tableView.tableHeaderView =
-      UIView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: (view.frame.height) * 0.02))
+      UIView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: (view.frame.height) * 0.01))
     tableView.tableFooterView =
-      UIView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: (view.frame.height) * 0.02))
+      UIView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: (view.frame.height) * 0.01))
     tableView.separatorStyle = .none // 테이블 뷰 라인 없애기
     tableView.register(cell: CategoryTableViewCell.self)
-    tableView.register(UITableViewCell.self, forCellReuseIdentifier: "often")
-    tableView.register(UITableViewCell.self, forCellReuseIdentifier: "temp")
-    tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+    tableView.register(cell: UITableViewCell.self)
     [tableView].forEach {
       view.addSubview($0)
     }
@@ -51,7 +50,6 @@ class CategoryViewController: UIViewController {
 // MARK: - TableViewDataSource
 extension CategoryViewController: UITableViewDataSource {
   func numberOfSections(in tableView: UITableView) -> Int {
-//    3
     return categoryData.count + 2
   }
   
@@ -60,8 +58,6 @@ extension CategoryViewController: UITableViewDataSource {
     case 0, 16:
       return 1
     default:
-//      print(section)
-//      return 1
       if categoryData[section - 1].select {
         return categoryData[section - 1].row.count + 1
       } else {
@@ -73,7 +69,7 @@ extension CategoryViewController: UITableViewDataSource {
   func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     switch indexPath.section {
     case 0:
-      let cell = tableView.dequeueReusableCell(withIdentifier: "often", for: indexPath)
+      let cell = tableView.dequeue(UITableViewCell.self)
       cell.textLabel?.text = oftenProduct[indexPath.section]
       cell.textLabel?.textColor = #colorLiteral(red: 0.3176470588, green: 0.1529411765, blue: 0.4470588235, alpha: 1)
       let image = UIImageView(image: UIImage(systemName: "chevron.right"))
@@ -81,7 +77,7 @@ extension CategoryViewController: UITableViewDataSource {
       cell.accessoryView?.tintColor = #colorLiteral(red: 0.3176470588, green: 0.1529411765, blue: 0.4470588235, alpha: 1)
       return cell
     case 16:
-      let cell = tableView.dequeueReusableCell(withIdentifier: "temp", for: indexPath)
+      let cell = tableView.dequeue(UITableViewCell.self)
       cell.textLabel?.text = "컬리의 추천"
       return cell
     default:
@@ -90,11 +86,13 @@ extension CategoryViewController: UITableViewDataSource {
         let data = categoryData[indexPath.section - 1]
         cell.titleName(name: data.title)
         cell.subCategory(data: data)
-        cell.separatorInset = .zero
         return cell
       } else {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "cell") else { return UITableViewCell() }
-        cell.textLabel?.text = categoryData[indexPath.section - 1].row[indexPath.row - 1]
+        let cell = tableView.dequeue(UITableViewCell.self)
+        let data =
+          categoryData[indexPath.section - 1].row[indexPath.row - 1]
+        cell.textLabel?.text = data
+        cell.backgroundColor = #colorLiteral(red: 0.9490196078, green: 0.9490196078, blue: 0.968627451, alpha: 1)
         return cell
       }
     }
@@ -109,10 +107,20 @@ extension CategoryViewController: UITableViewDelegate {
       print(indexPath.section)
     default:
       if indexPath.row == 0 {
-        categoryData[indexPath.section - 1].select.toggle()
-//        tableView.reloadData()
-        let row = IndexSet.init(integer: indexPath.section)
-        tableView.reloadSections(row, with: .none)
+        var sections: IndexSet = []
+
+        if let lastSection = lastSelection?.section {
+          categoryData[lastSection - 1].select = false
+          sections.insert(lastSection)
+        }
+        if lastSelection == indexPath {
+          lastSelection = nil
+        } else {
+          lastSelection = indexPath
+          categoryData[indexPath.section - 1].select.toggle()
+          sections.insert(indexPath.section)
+        }
+        tableView.reloadSections(sections, with: .none)
       } else {
         // Todo: 다음페이지 넘김
         print(indexPath.row)
@@ -134,7 +142,7 @@ extension CategoryViewController: UITableViewDelegate {
   func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
     switch section {
     case 16:
-      return 20
+      return 10
     default:
       return 0
     }
@@ -142,14 +150,14 @@ extension CategoryViewController: UITableViewDelegate {
   func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
     switch section {
     case 0:
-      return 20
+      return 10
     default:
       return 0
     }
   }
   func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
      if indexPath.section == 0 {
-       return 60
+       return 52
      } else {
        return UITableView.automaticDimension
      }

--- a/MarketBroccoli/MarketBroccoli/Source/Views/CategoryTableViewCell.swift
+++ b/MarketBroccoli/MarketBroccoli/Source/Views/CategoryTableViewCell.swift
@@ -18,8 +18,6 @@ class CategoryTableViewCell: UITableViewCell {
   private let arrowImage = UIImageView()
   private let subCategoryView = UIView()
   
-  private var bottomConstraint: NSLayoutConstraint?
-  private var testConstraint: Constraint?
     
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -41,10 +39,8 @@ class CategoryTableViewCell: UITableViewCell {
     switch data.select {
     case true:
       subCategoryView.isHidden = false
-      testConstraint?.update(priority: .low)
     case false:
       subCategoryView.isHidden = true
-      testConstraint?.update(priority: .high)
     }
   }
   
@@ -82,25 +78,13 @@ class CategoryTableViewCell: UITableViewCell {
       make.trailing.equalTo(contentView.snp.trailing).offset(-20)
       make.width.height.equalTo(20)
     }
-    subCategoryView.snp.makeConstraints { (make) -> Void in
-      make.top.equalTo(iconImage.snp.bottom).offset(10)
-      make.leading.equalTo(contentView.snp.leading)
-      make.trailing.equalTo(contentView.snp.trailing)
-
-      make.height.equalTo(contentView.snp.height).multipliedBy(2)
-    }
-  
-//    contentView.snp.makeConstraints { (make) -> Void in
-//      make.bottom.equalTo(subCategoryView.snp.bottom).priority(.medium)
-//      make.bottom.equalTo(iconImage.snp.bottom).offset(16).priority(.low)
-//    }
-    
-//    tableView.snp.makeConstraints { (make) -> Void in
+//    subCategoryView.snp.makeConstraints { (make) -> Void in
 //      make.top.equalTo(iconImage.snp.bottom).offset(10)
-//      make.leading.equalToSuperview()
-//      make.trailing.equalToSuperview()
-//      make.height.equalTo(contentView.snp.height).multipliedBy(6)
+//      make.leading.equalTo(contentView.snp.leading)
+//      make.trailing.equalTo(contentView.snp.trailing)
+//      make.height.equalTo(contentView.snp.height).multipliedBy(2)
 //    }
+
   }
   
   func titleName(name: String) {

--- a/MarketBroccoli/MarketBroccoli/Source/Views/CategoryTableViewCell.swift
+++ b/MarketBroccoli/MarketBroccoli/Source/Views/CategoryTableViewCell.swift
@@ -64,13 +64,13 @@ class CategoryTableViewCell: UITableViewCell {
   private func setupLayout() {
     iconImage.snp.makeConstraints { (make) -> Void in
       make.centerY.equalTo(contentView.snp.centerY)
-      make.leading.equalTo(contentView.snp.leading).offset(10)
-      make.width.height.equalTo(40)
+      make.leading.equalTo(contentView.snp.leading).offset(16)
+      make.width.height.equalTo(32)
     }
     title.snp.makeConstraints { (make) -> Void in
-      make.top.equalTo(contentView.snp.top).offset(20)
-      make.leading.equalTo(iconImage.snp.trailing).offset(8)
-      make.bottom.equalToSuperview().offset(-20)
+      make.top.equalTo(contentView.snp.top).offset(16)
+      make.leading.equalTo(iconImage.snp.trailing).offset(10)
+      make.bottom.equalToSuperview().offset(-16)
     }
     arrowImage.snp.makeConstraints { (make) -> Void in
       make.centerY.equalTo(contentView.snp.centerY)

--- a/MarketBroccoli/MarketBroccoli/Source/Views/CategoryTableViewCell.swift
+++ b/MarketBroccoli/MarketBroccoli/Source/Views/CategoryTableViewCell.swift
@@ -18,7 +18,6 @@ class CategoryTableViewCell: UITableViewCell {
   private let arrowImage = UIImageView()
   private let subCategoryView = UIView()
   
-    
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
     setupUI()


### PR DESCRIPTION
- #33 
- 섹션과 셀을 동일하게 구조 수정
- 1번째 섹션에만 작동되던 기능 1~15 섹션에도 동일하게 적용
- 카테고리 테이블 뷰 접었다 폈다 하는 기능 구현 완료 -> 문제 되는 부분 수정
- 카테고리 테이블 뷰 - 셀 눌렀을 때 딱! 하나만 접었다 펴는 기능 완료